### PR TITLE
Jira Comment Sync to Shotgun Notes

### DIFF
--- a/sg_jira/errors.py
+++ b/sg_jira/errors.py
@@ -13,8 +13,8 @@ class InvalidSyncValue(ValueError):
     """
     def __init__(self, field, value, *args, **kwargs):
         """
-        :param str field: The Jira field for which the exception was raised.
-        :param value: The Shotgun value for which the exception was raised.
+        :param str field: The Jira or SG field for which the exception was raised.
+        :param value: The Jira or SG value for which the exception was raised.
         """
         super(InvalidSyncValue, self).__init__(*args, **kwargs)
         self._field = field

--- a/sg_jira/handlers/sync_handler.py
+++ b/sg_jira/handlers/sync_handler.py
@@ -192,6 +192,7 @@ class SyncHandler(object):
         :param shotgun_field_schema: The Shotgun Entity field schema.
         :param change: A Jira event changelog dictionary with 'fromString',
                        'toString', 'from' and 'to' keys.
+        :param jira_value: The full current Jira value.
         :raises: RuntimeError if the Shotgun Entity can't be retrieved from Shotgun.
         :raises: ValueError for unsupported Shotgun data types.
         """

--- a/webapp.py
+++ b/webapp.py
@@ -237,6 +237,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 )
                 return
             self.send_response(200, "POST request successful")
+            self.end_headers()
         except Exception as e:
             self.send_error(500, e.message)
 


### PR DESCRIPTION
## Jira Comment to Shotgun Note Syncing
Comment updates on Jira Issues are now synced back to the corresponding Shotgun Note if there is one (the Shotgun to Jira implementation already exists).

Since Jira does not have a separate subject field for comments, Jira Comments that were created by the SG Jira Bridge currently have a specific format to mimic the Subject and Content structure that Shotgun has. 

When syncing back to Shotgun, if the format doesn't match what we expect, and we cannot parse a `subject` and `content` value for the Shotgun Note, we skip the update. We don't attempt to figure out what went wrong in order to avoid creating a mess and potentially syncing incorrect or incomplete values.

No syncing occurs when new Comments are created in Jira nor when Comments are deleted in Jira.

## Fixes
Fixed a small issue with the web server returning a 503 error because we weren't sending headers back correctly on POST requests
