### PR TITLE
Improved Logging

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -164,8 +164,7 @@ If you change a status in Shotgun or Jira and there's no matching status value
 defined by the mapping in your handlers for the change, then you will see
 something like this in the logs::
 
-    DEBUG:sg_jira.syncer.default:Don't know how to sync Shotgun Task sg_status_list field to Jira
-    WARNING:sg_jira.syncer.default:Unable to retrieve corresponding Jira status for na
+    2019-03-11 15:59:09,517 WARNING [entity_issue_handler] Unable to find a matching Jira status for Shotgun status 'na'
 
 In this case, there is no Jira status defined in the handlers to match with
 the ``na`` status in Shotgun. Your handler defines a

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -1,7 +1,7 @@
 .. _known_issues:
 
-Known Issues
-############
+Known Issues & Compatibility Notes
+##################################
 
 Because Shotgun and Jira are both highly customizable and have different APIs,
 there are some cases where things may not match up as expected. There are also
@@ -42,3 +42,11 @@ cases where certain features have not been implemented yet.
   may enable unique values on the **Jira Key** in Shotgun, however this will
   now generate an error in Shotgun if a synced Entity is duplicated. Perhaps
   it's better than possibly corrupting the synced Jira Issue. 
+
+- Jira single-line `Text Field` fields are limited to 255 characters. When 
+  syncing from Shotgun to Jira, if the Shotgun field is mapped to a Jira
+  single-line Text Field, and the value is longer than 255 characters, a
+  warning is logged, the synced value will be truncated and an addendum added
+  that says to look in Shotgun for the full value. This could cause data loss
+  if the field is then updated in Jira which will overwrite the original value
+  in Shotgun.

--- a/settings.py
+++ b/settings.py
@@ -48,10 +48,20 @@ LOGGING = {
             "console", "file"
         ],
     },
+    "loggers": {
+        # Set web server level to WARNING so we don't hear about every request
+        # If you want to see the requests in the logs, set this to INFO.
+        "webapp": {
+            "level": "WARNING"
+        }
+    },
     # Some formatters, mainly as examples
     "formatters": {
         "verbose": {
-            "format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
+            "format": "%(asctime)s %(levelname)s [%(module)s %(process)d %(thread)d] %(message)s"
+        },
+        "standard": {
+            "format": "%(asctime)s %(levelname)s [%(module)s] %(message)s"
         },
         "simple": {
             "format": "%(levelname)s:%(name)s:%(message)s"
@@ -61,14 +71,14 @@ LOGGING = {
     "handlers": {
         # Print out any message to stdout
         "console": {
-            "level": "DEBUG",
+            "level": "INFO",
             "class": "logging.StreamHandler",
-            "formatter": "simple"
+            "formatter": "standard"
         },
         "file": {
             "level": "INFO",
             "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "simple",
+            "formatter": "standard",
             "filename": "/tmp/sg_jira.log",
             "maxBytes": 1024 * 1024,
             "backupCount": 5

--- a/sg_jira/handlers/enable_syncing_handler.py
+++ b/sg_jira/handlers/enable_syncing_handler.py
@@ -87,9 +87,9 @@ class EnableSyncingHandler(SyncHandler):
         # Run the primary handler, stop processing if the primary handler
         # didn't perform anything.
         self._logger.debug(
-            "Dispatching event %s to primary handler %s" % (
-                event,
-                self._primary_handler
+            "Dispatching event to primary handler %s. Event: %s" % (
+                self._primary_handler,
+                event
             )
         )
         if not self._primary_handler.process_shotgun_event(
@@ -102,9 +102,9 @@ class EnableSyncingHandler(SyncHandler):
         # Run all the secondary handlers
         for handler in self._secondary_handlers:
             self._logger.debug(
-                "Dispatching event %s to secondary handler %s" % (
-                    event,
-                    handler
+                "Dispatching event to secondary handler %s. Event: %s" % (
+                    handler,
+                    event
                 )
             )
             handler.process_shotgun_event(

--- a/sg_jira/shotgun_session.py
+++ b/sg_jira/shotgun_session.py
@@ -229,7 +229,7 @@ class ShotgunSession(object):
             )
             if not consolidated:
                 logger.warning(
-                    "Unable to retrieve %s %d in Shotgun." % (
+                    "Unable to find %s (%d) in Shotgun" % (
                         shotgun_entity["type"],
                         shotgun_entity["id"],
                     )

--- a/sg_jira/syncer.py
+++ b/sg_jira/syncer.py
@@ -65,8 +65,7 @@ class Syncer(object):
         and cache any value which is slow to retrieve.
         """
         self._logger.debug(
-            "Checking if the Shotgun site and the Jira server are correctly "
-            "configured."
+            "Checking if the Shotgun and Jira sites are correctly configured."
         )
         for handler in self.handlers:
             handler.setup()

--- a/sg_jira/utils.py
+++ b/sg_jira/utils.py
@@ -37,8 +37,8 @@ def utf8_to_unicode(value):
                 decoded_key = k.decode("utf-8")
                 if decoded_key in [x for x in value.keys() if isinstance(x, unicode)]:
                     raise ValueError(
-                        "UTF-8 decoded key %s is already present "
-                        "in dictionary being decoded" % (
+                        "UTF-8 decoded key %s is already present in dictionary "
+                        "being decoded" % (
                             decoded_key,
                         )
                     )

--- a/sg_jira_event_trigger.py
+++ b/sg_jira_event_trigger.py
@@ -97,7 +97,7 @@ def process_event(sg, logger, event, dispatch_routes):
         if not sg_project:
             # This shouldn't happen, but better to be safe here.
             logger.warning(
-                "Unable to retrieve a Shotgun Project "
+                "Unable to find a Shotgun Project "
                 "with id %d, skipping event..." % (
                     project["id"]
                 )

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -518,7 +518,7 @@ class TestJiraSyncer(TestSyncBase):
             # This should fail because of missing data for the required "Faked" field
             self.assertRaisesRegexp(
                 ValueError,
-                r"The following data is missing in order to create a Jira Task Issue: \['Faked'\]",
+                r"Unable to create Jira Task Issue. The following required data is missing: \['Faked'\]",
                 bridge.sync_in_jira,
                 "task_issue",
                 "Task",


### PR DESCRIPTION
## Log message updates
Lots of log message tweaking. I focused on making the INFO level logs readable and consistent while still having enough information to be able to see exactly what's happening. WARNING messages and Exceptions should have enough information (to a point) to be able to fix the error without requiring turning on DEBUG mode to investigate further.

When long strings of data are logged (typically for DEBUG level messages), this information is moved to the end of the message so the actual message can be read easily at the beginning.

## Log settings
* Set the `webapp` logger to WARNING so we don't create a lot of noise in the logs for successful messages. **Question**: Do you want to log INFO-level webapp requests? Currently we do not but see the example below to see the difference.
*Updated the logging format to be a little cleaner and closer to TK formats. Added a new "standard" format which is in-between simple and verbose.

### Example INFO output
Here's an arbitrary set of messages generated while using the sync. I purposefully caused some warnings to show as examples.

**Without webapp INFO messages logged**
```
2019-03-12 08:36:55,153 INFO [bridge] Successfully read settings from /Users/kp/Documents/dev/sg-jira-bridge/settings.py
2019-03-12 08:36:55,428 INFO [shotgun_session] Connected to https://kp.shotgunstudio.com.
2019-03-12 08:36:56,582 INFO [jira_session] Connected to https://sgpipeline.atlassian.net.
2019-03-12 08:37:34,239 INFO [task_issue_handler] Syncing Shotgun Task.task_assignees (5592) to Jira Task KP-21
2019-03-12 08:37:35,889 WARNING [jira_session] Unable to find a Jira user with email steve@stevekahwati.com for Issue KP-21
2019-03-12 08:37:43,966 INFO [task_issue_handler] Syncing Shotgun Task.task_assignees (5592) to Jira Task KP-21
2019-03-12 08:39:02,627 INFO [task_issue_handler] Syncing Shotgun Task.sg_description (5592) to Jira Task KP-21
2019-03-12 08:39:59,501 INFO [note_comment_handler] Jira issue KP-20 Comment 13397 updated. Syncing to Shotgun Note (6464)
2019-03-12 08:41:12,396 INFO [task_issue_handler] Syncing Shotgun Task.sg_status_list (5592) to Jira Task KP-21
2019-03-12 08:41:12,647 INFO [jira_session] Transitioning Issue KP-21 to 'In Progress' with params: {'comment': u'Updated from Shotgun Task (5592) moving to ip'}
```

**With webapp INFO messages logged**
```
2019-03-12 08:36:55,153 INFO [bridge] Successfully read settings from /Users/kp/Documents/dev/sg-jira-bridge/settings.py
2019-03-12 08:36:55,428 INFO [shotgun_session] Connected to https://kp.shotgunstudio.com.
2019-03-12 08:36:56,582 INFO [jira_session] Connected to https://sgpipeline.atlassian.net.
2019-03-12 08:37:34,239 INFO [task_issue_handler] Syncing Shotgun Task.task_assignees (5592) to Jira Task KP-21
2019-03-12 08:37:35,889 WARNING [jira_session] Unable to find a Jira user with email steve@stevekahwati.com for Issue KP-21
2019-03-12 08:37:42,458 INFO [webapp] 127.0.0.1 - "POST /sg2jira/default/Task/5592 HTTP/1.1" 200 -
2019-03-12 08:37:43,966 INFO [task_issue_handler] Syncing Shotgun Task.task_assignees (5592) to Jira Task KP-21
2019-03-12 08:37:49,172 INFO [webapp] 127.0.0.1 - "POST /sg2jira/default/Task/5592 HTTP/1.1" 200 -
2019-03-12 08:39:02,627 INFO [task_issue_handler] Syncing Shotgun Task.sg_description (5592) to Jira Task KP-21
2019-03-12 08:39:08,078 INFO [webapp] 127.0.0.1 - "POST /sg2jira/default/Task/5592 HTTP/1.1" 200 -
2019-03-12 08:39:08,256 INFO [webapp] 127.0.0.1 - "POST /jira2sg/default/issue/KP-21?user_id=kporangehat%2Bsgjirasync&user_key=kporangehat%2Bsgjirasync HTTP/1.1" 200 -
2019-03-12 08:39:59,501 INFO [note_comment_handler] Jira issue KP-20 Comment 13397 updated. Syncing to Shotgun Note (6464)
2019-03-12 08:39:59,667 INFO [webapp] 127.0.0.1 - "POST /jira2sg/default/issue/KP-20?user_id=kevin.porterfield&user_key=kevin.porterfield HTTP/1.1" 200 -
2019-03-12 08:40:04,693 INFO [webapp] 127.0.0.1 - "POST /sg2jira/default/Note/6464 HTTP/1.1" 200 -
2019-03-12 08:41:12,396 INFO [task_issue_handler] Syncing Shotgun Task.sg_status_list (5592) to Jira Task KP-21
2019-03-12 08:41:12,647 INFO [jira_session] Transitioning Issue KP-21 to 'In Progress' with params: {'comment': u'Updated from Shotgun Task (5592) moving to ip'}
2019-03-12 08:41:13,081 INFO [webapp] 127.0.0.1 - "POST /sg2jira/default/Task/5592 HTTP/1.1" 200 -
2019-03-12 08:41:13,492 INFO [webapp] 127.0.0.1 - "POST /jira2sg/default/issue/KP-21?user_id=kporangehat%2Bsgjirasync&user_key=kporangehat%2Bsgjirasync HTTP/1.1" 200 -
```

## Misc
* Added compatibility note to docs about Jira's single-line text field 255 character limit
* Added fix for usernames with special characters. Jira api stores them encoded, now we decode the username when accessing it from the Jira api.

## Docs
Latest build of the docs (only a small change was added) 
[sg-jira-bridge-docs_658_improved_logging.zip](https://github.com/shotgunsoftware/sg-jira-bridge/files/2959962/sg-jira-bridge-docs_658_improved_logging.zip)


## Questions
* Do you want to log INFO-level webapp requests? Currently we do not but see the example above to see the difference.
* Any log messages about rejecting events (due to unsupported fields, wrong entity types, etc.) are currently at the DEBUG level. Do you want these to be INFO so they *all* show up in the logs by default? This could be a lot of messages (concise small messages but higher volume). Or shall we leave them at DEBUG?