### PR TITLE
SG-12125: jira GDPR fix

### DIFF
--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -89,11 +89,12 @@ class JiraSession(jira.client.JIRA):
     # This is a partial port of the code found in the master branch of the JIRA module.
     # Instead of using it to retrieve the current user name, we'll use it to get
     # the current account id.
+    # Once the 2.1.0 of the API gets released, we'll reevaluate this code and implement
+    # the logic with the proper API calls.
     # https://github.com/pycontribs/jira/blob/ca306d7e59caa739e8707fec8be3c260340684ac/jira/client.py#L3326-L3348
     def current_user_id(self):
         """
-        Returns the account-id of the current user. For anonymous
-        users it will return a value that evaluates as False.
+        Returns the account-id of the current user.
 
         :rtype: str
         """

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -98,9 +98,9 @@ class JiraSession(jira.client.JIRA):
 
         :rtype: str
         """
-        if not hasattr(self, '_myself'):
-            url = self._get_url('myself')
-            r = self._session.get(url, headers=self._options['headers'])
+        if not hasattr(self, "_myself"):
+            url = self._get_url("myself")
+            r = self._session.get(url, headers=self._options["headers"])
             r_json = r.json()
             self._myself = r_json
         return self._myself["accountId"]

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -86,6 +86,24 @@ class JiraSession(jira.client.JIRA):
                 "Missing required custom Jira field %s" % JIRA_SHOTGUN_URL_FIELD
             )
 
+    # This is a partial port of the code found in the master branch of the JIRA module.
+    # Instead of using it to retrieve the current user name, we'll use it to get
+    # the current account id.
+    # https://github.com/pycontribs/jira/blob/ca306d7e59caa739e8707fec8be3c260340684ac/jira/client.py#L3326-L3348
+    def current_user_id(self):
+        """
+        Returns the account-id of the current user. For anonymous
+        users it will return a value that evaluates as False.
+
+        :rtype: str
+        """
+        if not hasattr(self, '_myself'):
+            url = self._get_url('myself')
+            r = self._session.get(url, headers=self._options['headers'])
+            r_json = r.json()
+            self._myself = r_json
+        return self._myself["accountId"]
+
     def get_jira_issue_field_id(self, name):
         """
         Return the Jira field id for the Issue field with the given name.

--- a/sg_jira/syncer.py
+++ b/sg_jira/syncer.py
@@ -159,6 +159,14 @@ class Syncer(object):
         # Check we didn't trigger the event to avoid infinite loops.
         user = event.get("user")
         if user:
+            # TODO: Need to run this code on the local install of JIRA and
+            if "accountId" in user and user["accountId"] == self.bridge.jira.current_user_id():
+                self._logger.debug("Rejecting event %s triggered by us (%s)" % (
+                    event,
+                    user["accountId"],
+                ))
+                return None
+
             if user["name"].lower() == self.bridge.current_jira_username.lower():
                 self._logger.debug("Rejecting event %s triggered by us (%s)" % (
                     event,

--- a/sg_jira/syncer.py
+++ b/sg_jira/syncer.py
@@ -159,7 +159,6 @@ class Syncer(object):
         # Check we didn't trigger the event to avoid infinite loops.
         user = event.get("user")
         if user:
-            # TODO: Need to run this code on the local install of JIRA and
             if "accountId" in user and user["accountId"] == self.bridge.jira.current_user_id():
                 self._logger.debug("Rejecting event %s triggered by us (%s)" % (
                     event,
@@ -167,13 +166,14 @@ class Syncer(object):
                 ))
                 return None
 
-            if user["name"].lower() == self.bridge.current_jira_username.lower():
+            if "name" in user and user["name"].lower() == self.bridge.current_jira_username.lower():
                 self._logger.debug("Rejecting event %s triggered by us (%s)" % (
                     event,
                     user["name"],
                 ))
                 return None
-            if user["emailAddress"].lower() == self.bridge.current_jira_username.lower():
+
+            if "emailAddress" in user and user["emailAddress"].lower() == self.bridge.current_jira_username.lower():
                 self._logger.debug("Rejecting event %s triggered by us (%s)" % (
                     event,
                     user["emailAddress"],

--- a/sg_jira/syncer.py
+++ b/sg_jira/syncer.py
@@ -166,6 +166,13 @@ class Syncer(object):
                 ))
                 return None
 
+            # TODO: It's hard to tell if these next to ifs are actually needed anymore.
+            # From testing it seems that accountId is always set, so testing for name
+            # and emailAddress is probably not needed anymore. We've left these tests
+            # for now as we don't have access to a JIRA local instance to test on, which
+            # may (but unlikely) behave differently.
+
+            # On GDPR compliant versions of JIRA, the name field is not returned.
             if "name" in user and user["name"].lower() == self.bridge.current_jira_username.lower():
                 self._logger.debug("Rejecting event %s triggered by us (%s)" % (
                     event,
@@ -173,6 +180,9 @@ class Syncer(object):
                 ))
                 return None
 
+            # The email field is always present, even on GDPR versions of JIRA, but set to "?".
+            # Protect ourselves here by testing for it's presence since it wouldn't be surprising
+            # if it was completely removed at some point.
             if "emailAddress" in user and user["emailAddress"].lower() == self.bridge.current_jira_username.lower():
                 self._logger.debug("Rejecting event %s triggered by us (%s)" % (
                     event,

--- a/tests/python/test_sync_base.py
+++ b/tests/python/test_sync_base.py
@@ -10,7 +10,7 @@ import mock
 
 
 from shotgun_api3.lib import mockgun
-from mock_jira import MockedJira
+from mock_jira import MockedJira, JIRA_USER
 import sg_jira
 
 from test_base import TestBase
@@ -72,6 +72,18 @@ class TestSyncBase(TestBase):
             self._fixtures_path,
             "schemas", "sg-jira",
         ))
+
+        # Mocks the current_user_id which depends on introspecting
+        # data coming back from the JIRA API and that we won't
+        # simulate for these tests.
+        patcher = mock.patch.object(
+            sg_jira.jira_session.JiraSession,
+            "current_user_id",
+            lambda _: JIRA_USER["accountId"]
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
         # Patch the JiraSession base class to use our MockedJira instead of
         # the jira.client.Jira class.
         patcher = mock.patch.object(

--- a/tests/python/test_sync_base.py
+++ b/tests/python/test_sync_base.py
@@ -73,9 +73,9 @@ class TestSyncBase(TestBase):
             "schemas", "sg-jira",
         ))
 
-        # Mocks the current_user_id which depends on introspecting
-        # data coming back from the JIRA API and that we won't
-        # simulate for these tests.
+        # Mocks the "current_user_id" method which depends on
+        # introspecting data coming back from the JIRA API and
+        # that we won't simulate for these tests.
         patcher = mock.patch.object(
             sg_jira.jira_session.JiraSession,
             "current_user_id",

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -294,7 +294,7 @@ class TestJiraSyncer(TestSyncBase):
         correctly handled.
         """
         # Bad setup should raise an exception
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError,
             "Sorry, I'm bad!",
             self._get_syncer,
@@ -305,7 +305,7 @@ class TestJiraSyncer(TestSyncBase):
         bridge = sg_jira.Bridge.get_bridge(
             os.path.join(self._fixtures_path, "settings.py")
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError,
             "Sorry, I'm bad!",
             bridge.sync_in_jira,
@@ -318,7 +318,7 @@ class TestJiraSyncer(TestSyncBase):
                 "meta": SG_EVENT_META
             }
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError,
             "Sorry, I'm bad!",
             bridge.sync_in_jira,
@@ -516,7 +516,7 @@ class TestJiraSyncer(TestSyncBase):
         # Test missing values in data
         with mock.patch.object(syncer.jira, "createmeta", return_value=createmeta) as m_cmeta:  # noqa
             # This should fail because of missing data for the required "Faked" field
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 ValueError,
                 r"Unable to create Jira Task Issue. The following required data is missing: \['Faked'\]",
                 bridge.sync_in_jira,


### PR DESCRIPTION
Fixes the issue with GDPR compliant JIRA Cloud sites which do not expose the name field and return `?` as the email address. To get around this, we simply use the `accountId` of the user instead.

I've left the previous code just in case due to my inexperience with the JIRA API and covering our bases in case the behaviour changes again on the server side.