### PR TITLE
SG-14475: Multithreaded web server

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -59,7 +59,10 @@ HumanUser     ``sg_jira_account_id``   Text        Jira Account Id              
 
 .. note::
     - All ``sg_jira_key`` fields must be configured with the "*Ensure unique
-      value per project*" setting **checked**.
+      value per project*" setting **checked**. This setting can be found by
+      showing the relevant field in an entity spreadsheet view and then
+      right clicking the header for that column. Select the ``Configure field...``
+      menu option.
     - The ``HumanUser.sg_jira_account_id`` field is only necessary if your
       Jira server is hosted by Atlassian.
 
@@ -121,6 +124,12 @@ Jira Webhook
 +--------------+-----------------------------------------------------------------------------------------+
 | Exclude Body | (`required`) **[ ] un-checked**                                                         |
 +--------------+-----------------------------------------------------------------------------------------+
+
+.. note::
+    If you are setting up a local development environment and need Jira to have access to localhost
+    in order for the Jira webhook to successfully delivery its payload to the bridge, be sure to
+    follow the instructions in the ``Testing on a Machine Not Accessible to Jira`` section of the
+    debugging guide.
 
 
 Setting Up Your Config and Env
@@ -200,7 +209,12 @@ and define these in a ``.env`` file.
 
     Since Jira does not have a concept of a "script" user, ``SGJIRA_JIRA_USER``
     will need to be the designated user account, with appropriate
-    permissions, that will control the sync updates.
+    permissions, that will control the sync updates. Note that the user should
+    not be your personal user account, as the bridge will ignore and not sync
+    to Shotgun any events triggered in Jira by that user. This ensures that
+    the bridge will not end up in a "ping pong" state, where it bounces the
+    same event back-and-forth between Jira and Shotgun. As such, you will need
+    to create a dedicated user account in Jira for use with the bridge.
 
 
 shotgunEvents

--- a/sg_jira/bridge.py
+++ b/sg_jira/bridge.py
@@ -11,6 +11,7 @@ import logging
 import logging.config
 import importlib
 import urllib
+import threading
 
 from .shotgun_session import ShotgunSession
 from .jira_session import JiraSession
@@ -22,6 +23,12 @@ from .utils import utf8_to_unicode
 logger = logging.getLogger(__name__)
 # Ensure basic logging is always enabled
 logging.basicConfig(format="%(levelname)s:%(name)s:%(message)s")
+
+# The bridge webserver is multithreaded, which means we need to
+# track Shotgun connections via the API per thread. The SG Python
+# API is not threadsafe, and using a single, global connection
+# across all threads will lead to some weird behavior.
+_g_sg_cached_connections = threading.local()
 
 
 class Bridge(object):
@@ -64,13 +71,27 @@ class Bridge(object):
                                   connection, or None.
         """
         super(Bridge, self).__init__()
-        self._shotgun = ShotgunSession(
+
+        self._sg_site = sg_site
+        self._sg_script = sg_script
+        self._sg_script_key = sg_script_key
+        self._sg_http_proxy = sg_http_proxy
+
+        # Even though we will end up needing a connection per thread, we
+        # still need to do a one-time check to make sure the site we're
+        # connecting to is setup properly for use with the bridge. That
+        # logic is run via the setup() method on the session object, so
+        # we will connect here and call that a single time since there's
+        # no reason to do that validation pass from each thread when we
+        # create new connections.
+        shotgun = ShotgunSession(
             sg_site,
             script_name=sg_script,
             api_key=sg_script_key,
             http_proxy=sg_http_proxy,
         )
-        self._shotgun.add_user_agent("sg_jira_sync")
+        shotgun.add_user_agent("sg_jira_sync")
+        shotgun.setup()
 
         self._jira_user = jira_user
         self._jira = JiraSession(
@@ -83,7 +104,6 @@ class Bridge(object):
         self._sync_settings = sync_settings or {}
         self._syncers = {}
         self._jira.setup()
-        self._shotgun.setup()
 
     @classmethod
     def get_bridge(cls, settings_file):
@@ -200,7 +220,23 @@ class Bridge(object):
         """
         Return a connected :class:`~shotgun_session.ShotgunSession` instance.
         """
-        return self._shotgun
+        # This ensures we end up with a connection per thread. See the comment
+        # at the top of this file where the global cache is initialized for a
+        # full explanation.
+        global _g_sg_cached_connections
+        sg = getattr(_g_sg_cached_connections, "sg", None)
+
+        if sg is None:
+            sg = ShotgunSession(
+                self._sg_site,
+                script_name=self._sg_script,
+                api_key=self._sg_script_key,
+                http_proxy=self._sg_http_proxy,
+            )
+            sg.add_user_agent("sg_jira_sync")
+            _g_sg_cached_connections.sg = sg
+
+        return sg
 
     @property
     def current_shotgun_user(self):
@@ -209,7 +245,7 @@ class Bridge(object):
 
         :returns: A Shotgun record dictionary with an `id` key and a `type` key.
         """
-        return self._shotgun.current_user
+        return self.shotgun.current_user
 
     @property
     def current_jira_username(self):
@@ -323,7 +359,7 @@ class Bridge(object):
             # handlers.
             handler = syncer.accept_shotgun_event(entity_type, entity_id, safe_event)
             if handler:
-                self._shotgun.set_session_uuid(safe_event.get("session_uuid"))
+                self.shotgun.set_session_uuid(safe_event.get("session_uuid"))
                 synced = handler.process_shotgun_event(
                     entity_type,
                     entity_id,

--- a/webapp.py
+++ b/webapp.py
@@ -14,6 +14,8 @@ import ssl
 import logging
 import subprocess
 
+from SocketServer import ThreadingMixIn
+
 import sg_jira
 
 DESCRIPTION = """
@@ -116,9 +118,10 @@ class SgJiraBridgeBadRequestError(Exception):
     pass
 
 
-class Server(BaseHTTPServer.HTTPServer):
+class Server(ThreadingMixIn, BaseHTTPServer.HTTPServer):
     """
-    A web server
+    Basic server with threading functionality mixed in. This will help the server
+    keep up with a high volume of throughput from Shotgun and Jira.
     """
     def __init__(self, settings, *args, **kwargs):
         # Note: BaseHTTPServer.HTTPServer is not a new style class so we can't use

--- a/webapp.py
+++ b/webapp.py
@@ -127,8 +127,6 @@ class Server(ThreadingMixIn, BaseHTTPServer.HTTPServer):
         # Note: BaseHTTPServer.HTTPServer is not a new style class so we can't use
         # super here.
         BaseHTTPServer.HTTPServer.__init__(self, *args, **kwargs)
-
-        self.request_queue_size = 15
         self._sg_jira = sg_jira.Bridge.get_bridge(settings)
 
     def sync_in_jira(self, *args, **kwargs):

--- a/webapp.py
+++ b/webapp.py
@@ -127,6 +127,8 @@ class Server(ThreadingMixIn, BaseHTTPServer.HTTPServer):
         # Note: BaseHTTPServer.HTTPServer is not a new style class so we can't use
         # super here.
         BaseHTTPServer.HTTPServer.__init__(self, *args, **kwargs)
+
+        self.request_queue_size = 15
         self._sg_jira = sg_jira.Bridge.get_bridge(settings)
 
     def sync_in_jira(self, *args, **kwargs):


### PR DESCRIPTION
The bridge's web server is now multithreaded. This will allow it to handle large amounts of incoming requests from Jira when bulk edits occur. Jira processes bulk edits and fires off webhooks VERY quickly, and we were getting reports of the bridge being unable to reliably handle the deluge of incoming requests.