### PR TITLE
Bumping the version of dotenv in the requirements files 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ https://github.com/shotgunsoftware/python-api/archive/v3.0.39.zip
 daemonize==2.4.7
 
 # Allows defining env vars in a .env file that can be loaded at runtime
-python-dotenv==0.10.1
+python-dotenv==0.13.0

--- a/triggers/requirements.txt
+++ b/triggers/requirements.txt
@@ -19,4 +19,4 @@ requests==2.21.0
 https://github.com/shotgunsoftware/python-api/archive/v3.0.39.zip
 
 # Allows defining env vars in a .env file that can be loaded at runtime
-python-dotenv==0.10.1
+python-dotenv==0.13.0


### PR DESCRIPTION
This fixes an issue with finding the .env file on osx when using .pyc files