### PR TITLE
SG-30597 Adds support for Jira Python client 3.5.0. Drop support for Python 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)
-[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/)
 
 # ShotGrid Jira Bridge
 
@@ -24,7 +24,7 @@ Full documentation is available at https://developer.shotgridsoftware.com/sg-jir
 
 # Requirements
 
-- Python 2.7/3.7
+- Python 3.9
 - A [ShotGrid](https://shotgridsoftware.com) site
 - A [Jira](https://www.atlassian.com/software/jira) site
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,9 +21,17 @@ pr:
     - "*"
 
 jobs:
-- job: Lint
-  steps:
-  - template: azure-pipelines/flake8.yml
-- job: Tests
-  steps:
-  - template: azure-pipelines/tests.yml
+- template: azure-pipelines/flake8.yml
+- template: azure-pipelines/tests.yml
+  parameters:
+    name: Linux
+    vm_image: 'ubuntu-20.04'
+- template: azure-pipelines/tests.yml
+  parameters:
+    name: macOS
+    vm_image: 'macOS-12'
+# Commented until daemonize issue with fcntl import is resolved
+# - template: azure-pipelines/tests.yml
+#   parameters:
+#     name: Windows
+#     vm_image: 'windows-2022'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+trigger:
+  branches:
+    include:
+    - master
+  tags:
+    include:
+    - v*
+pr:
+  branches:
+    include:
+    - "*"
+
+jobs:
+- job: Lint
+  steps:
+  - template: azure-pipelines/flake8.yml
+- job: Tests
+  steps:
+  - template: azure-pipelines/tests.yml

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -6,12 +6,12 @@
 #
 
 pool:
-  vmImage: 'Ubuntu 16.04'
+  vmImage: 'ubuntu-22.04'
 
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 2.7
+    versionSpec: 3.9
     architecture: 'x64'
 
 - script: |

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -19,12 +19,9 @@ jobs:
       architecture: 'x64'
 
   - script: |
-      python -m pip install --upgrade pip setuptools wheel
-      pip install -r requirements.txt
-      pip install -r tests/requirements.txt
+      pip install --upgrade pip setuptools wheel
+      pip install -r requirements.txt -r tests/requirements.txt flake8
     displayName: Install dependencies
 
-  - script: |
-      python -m pip install flake8
-      flake8 .
+  - script: flake8 .
     displayName: 'Run flake8'

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -5,20 +5,26 @@
 # this software in either electronic or hard copy form.
 #
 
-pool:
-  vmImage: 'ubuntu-22.04'
+jobs:
 
-steps:
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: 3.9
-    architecture: 'x64'
+- job: ${{ parameters.name }}
+  pool:
+    vmImage: 'ubuntu-20.04'
 
-- script: |
-    python -m pip install --upgrade pip setuptools wheel
-  displayName: 'Install prerequisites'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: 3.9
+      addToPath: True
+      architecture: 'x64'
 
-- script: |
-    python -m pip install flake8
-    flake8 .
-  displayName: 'Run flake8'
+  - script: |
+      python -m pip install --upgrade pip setuptools wheel
+      pip install -r requirements.txt
+      pip install -r tests/requirements.txt
+    displayName: Install dependencies
+
+  - script: |
+      python -m pip install flake8
+      flake8 .
+    displayName: 'Run flake8'

--- a/azure-pipelines/tests.yml
+++ b/azure-pipelines/tests.yml
@@ -32,9 +32,8 @@ jobs:
       architecture: 'x64'
 
   - script: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-      pip install -r tests/requirements.txt
+      pip install --upgrade pip
+      pip install -r requirements.txt -r tests/requirements.txt
     displayName: Install dependencies
 
   - script: |

--- a/azure-pipelines/tests.yml
+++ b/azure-pipelines/tests.yml
@@ -6,8 +6,12 @@
 
 # This is the list of parameters for this template and their default values.
 parameters:
-  name: ''
-  vm_image: ''
+  - name: name
+    type: string
+    default: ''
+  - name: vm_image
+    type: string
+    default: ''
 
 jobs:
 

--- a/azure-pipelines/tests.yml
+++ b/azure-pipelines/tests.yml
@@ -3,17 +3,21 @@
 # Use of this software is subject to the terms of the Autodesk license agreement
 # provided at the time of installation or download, or which otherwise accompanies
 # this software in either electronic or hard copy form.
-#
+
+# This is the list of parameters for this template and their default values.
+parameters:
+  name: ''
+  vm_image: ''
 
 jobs:
 
-- job: 'Linux_test'
+- job: ${{ parameters.name }}
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: ${{ parameters.vm_image }}
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
+      Python37:
+        python.version: '3.7'
       Python39:
         python.version: '3.9'
     maxParallel: 2
@@ -22,89 +26,22 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
+      addToPath: True
       architecture: 'x64'
 
   - script: |
       python -m pip install --upgrade pip
       pip install -r requirements.txt
       pip install -r tests/requirements.txt
-    displayName: 'Install dependencies'
+    displayName: Install dependencies
 
   - script: |
       python tests/run_tests.py --xmlout test-results
-    displayName: 'Test SG Jira'
+    displayName: Test SG Jira
     env: { 'LANG': 'en_US.UTF-8' }
 
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: 'test-results/**.xml'
-      testRunTitle: 'Windows Python $(python.version)'
-    condition: succeededOrFailed()
-
-- job: 'Windows_test'
-  pool:
-    vmImage: 'windows-2022'
-  strategy:
-    matrix:
-      Python27:
-        python.version: '2.7'
-      Python39:
-        python.version: '3.9'
-    maxParallel: 2
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-      architecture: 'x64'
-
-  - script: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-      pip install -r tests/requirements.txt
-    displayName: 'Install dependencies'
-
-  - script: |
-      python tests/run_tests.py --xmlout test-results
-    displayName: 'Test SG Jira'
-    env: { 'LANG': 'en_US.UTF-8' }
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: 'test-results/**.xml'
-      testRunTitle: 'Windows Python $(python.version)'
-    condition: succeededOrFailed()
-
-- job: 'Mac_test'
-  pool:
-    vmImage: 'macOS-12'
-  strategy:
-    matrix:
-      Python27:
-        python.version: '2.7'
-      Python39:
-        python.version: '3.9'
-    maxParallel: 2
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-      architecture: 'x64'
-
-  - script: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-      pip install -r tests/requirements.txt
-    displayName: 'Install dependencies'
-
-  - script: |
-      python tests/run_tests.py --xmlout test-results
-    displayName: 'Test SG Jira'
-    env: { 'LANG': 'en_US.UTF-8' }
-
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFiles: 'test-results/**.xml'
-      testRunTitle: 'Windows Python $(python.version)'
+      testRunTitle: ${{ parameters.name }} Python $(python.version)
     condition: succeededOrFailed()

--- a/azure-pipelines/tests.yml
+++ b/azure-pipelines/tests.yml
@@ -20,8 +20,6 @@ jobs:
     vmImage: ${{ parameters.vm_image }}
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
       Python39:
         python.version: '3.9'
     maxParallel: 2

--- a/azure-pipelines/tests.yml
+++ b/azure-pipelines/tests.yml
@@ -9,12 +9,14 @@ jobs:
 
 - job: 'Linux_test'
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: 'ubuntu-22.04'
   strategy:
     matrix:
       Python27:
         python.version: '2.7'
-    maxParallel: 1
+      Python39:
+        python.version: '3.9'
+    maxParallel: 2
 
   steps:
   - task: UsePythonVersion@0
@@ -41,12 +43,14 @@ jobs:
 
 - job: 'Windows_test'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   strategy:
     matrix:
       Python27:
         python.version: '2.7'
-    maxParallel: 1
+      Python39:
+        python.version: '3.9'
+    maxParallel: 2
 
   steps:
   - task: UsePythonVersion@0
@@ -73,12 +77,14 @@ jobs:
 
 - job: 'Mac_test'
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-12'
   strategy:
     matrix:
       Python27:
         python.version: '2.7'
-    maxParallel: 1
+      Python39:
+        python.version: '3.9'
+    maxParallel: 2
 
   steps:
   - task: UsePythonVersion@0

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -307,7 +307,7 @@ Continuous Integration (CI)
 for the continuous integration and run the following validations:
 
 - Enforce reasonable PEP-8 conventions with Flake8.
-- Run unit tests on Linux, Mac and Windows with Python 2.7.
+- Run unit tests on Linux, Mac and Windows with Python 3.9.
 
 Azure Pipelines jobs are defined by the description files in the
 ``/azure-pipelines`` folder.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,7 +7,7 @@ The instructions below will help you get up and running quickly.
 
 Requirements
 ************
-- Python 2.7/3.7
+- Python 3.9
 - A ShotGrid site
 - A Jira site
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -384,3 +384,7 @@ shotgunEvents in your terminal window for log messages.
     the **Shotgun Type** and **Shotgun ID** fields as well as a link to the
     entity in ShotGrid in the **Shotgun URL** field. This is a good indicator
     that things are working correctly.
+
+.. note::
+    If you are using a Jira Server version 9 or later, API breaking changes
+    were introduced. Beta versions of sg-jira-bridge will be available soon.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,8 @@
 # Needed to run the Linux service.
 daemonize==2.4.7
 
-# Python Jira api.
-# Our fork provides a few fixes that are not part of the official API. Unfortunately
-# contributing back is going to be difficult because Python 2 is not supported anymore.
-git+https://github.com/shotgunsoftware/jira.git@2.0.0.sg.3#egg=jira
+# Python Jira client.
+jira==3.5.0
 
 # Install Shotgun API 3 from archive
 https://github.com/shotgunsoftware/python-api/archive/v3.2.4.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ daemonize==2.4.7
 jira==3.5.0
 
 # Install Shotgun API 3 from archive
-https://github.com/shotgunsoftware/python-api/archive/v3.2.4.zip
+https://github.com/shotgunsoftware/python-api/archive/v3.3.5.zip
 
 # Allows defining env vars in a .env file that can be loaded at runtime
 python-dotenv==0.13.0

--- a/sg_jira/bridge.py
+++ b/sg_jira/bridge.py
@@ -95,7 +95,11 @@ class Bridge(object):
         shotgun.setup()
 
         self._jira_user = jira_user
-        self._jira = JiraSession(jira_site, basic_auth=(jira_user, jira_secret),)
+        if jira_user == "None":
+            options = dict(token_auth=jira_secret)
+        else:
+            options = dict(basic_auth=(jira_user, jira_secret))
+        self._jira = JiraSession(jira_site, **options)
         self._sync_settings = sync_settings or {}
         self._syncers = {}
         self._jira.setup()

--- a/sg_jira/bridge.py
+++ b/sg_jira/bridge.py
@@ -95,10 +95,11 @@ class Bridge(object):
         shotgun.setup()
 
         self._jira_user = jira_user
-        if jira_user == "None":
-            options = dict(token_auth=jira_secret)
-        else:
-            options = dict(basic_auth=(jira_user, jira_secret))
+        options = (
+            {"token_auth": jira_secret}
+            if jira_user == "None"
+            else {"basic_auth": (jira_user, jira_secret)}
+        )
         self._jira = JiraSession(jira_site, **options)
         self._sync_settings = sync_settings or {}
         self._syncers = {}
@@ -321,7 +322,10 @@ class Bridge(object):
                 logger.debug("%s" % e, exc_info=True)
                 raise ValueError(
                     "Unable to retrieve a %s class from module %s"
-                    % (class_name, module,)
+                    % (
+                        class_name,
+                        module,
+                    )
                 )
             # Retrieve the settings for the syncer, if any
             settings = sync_settings.get("settings") or {}

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -6,15 +6,17 @@
 #
 
 import logging
+from packaging import version
 
 from jira import JIRAError
 import jira
 
 # Since we are using pbr in the forked jira repo, the tags we are using are marked as dev versions and
 # pip doesn't update them as expected.
-if not hasattr(jira.User, "user_id"):
+
+if version.parse(jira.__version__) < version.parse("3.5.0"):
     raise ImportError(
-        "The jira version installed is too old. Make sure it is updated to 2.0.0.sg.2+. "
+        "The jira version installed is too old. Make sure it is updated to 3.5.0. "
         'You can do this by using "pip install -r /path/to/requirements.txt --upgrade"'
     )
 

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -511,7 +511,8 @@ class JiraSession(jira.client.JIRA):
         # school projects and new simpler projects.
         # TODO: cache the retrieved data to avoid multiple requests to the server
 
-        if self._is_jira_cloud:
+        if self._is_jira_cloud or self._version < (9, 0, 0):
+            # Existing logic works for Jira Cloud or Jira Server 8 or prior.
             create_meta_data = self.createmeta(
                 jira_project,
                 issuetypeIds=jira_issue_type.id,
@@ -533,7 +534,7 @@ class JiraSession(jira.client.JIRA):
                 )
             fields_createmeta = create_meta_data["projects"][0]["issuetypes"][0]["fields"]
         else:
-            # Support for Jira Python client 3.5.0 (Jira 9.0.0)
+            # createmeta is not supported on Jira Server 9 and Python client 3.5.0
             create_meta_data = self.createmeta_issuetypes(
                 jira_project,
                 expand="values.fields",

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -532,7 +532,7 @@ class JiraSession(jira.client.JIRA):
                 )
             fields_createmeta = create_meta_data["projects"][0]["issuetypes"][0]["fields"]
         else:
-            # TODO: Change for Jira Server 9.0.0 and Jira Python client 3.5.0
+            # Support for Jira Python client 3.5.0 (Jira 9.0.0)
             create_meta_data = self.createmeta_issuetypes(
                 jira_project,
                 expand="values.fields",

--- a/tests/fixtures/schemas/generate_schema.py
+++ b/tests/fixtures/schemas/generate_schema.py
@@ -27,7 +27,7 @@ def main():
     args = parser.parse_args()
 
     sg_url = args.shotgun
-    sg = Shotgun(sg_url, login=raw_input("Login: "), password=getpass.getpass())
+    sg = Shotgun(sg_url, login=input("Login: "), password=getpass.getpass())
     schema_dir = args.path
     if not os.path.exists(schema_dir):
         os.makedirs(schema_dir)

--- a/tests/python/mock_jira.py
+++ b/tests/python/mock_jira.py
@@ -447,6 +447,17 @@ class MockedJira(object):
             if project.key == project_id:
                 return project
         raise JIRAError("Unable to find resource Project({})".format(project_id))
+    
+    def createmeta_issuetypes(self, *args):
+        """
+        Mocked Jira method.
+        Return a dictionary with create metadata for all projects.
+        """
+        return {
+            "values": [
+                {"fields": ISSUE_FIELDS}
+            ]
+        }
 
     def createmeta(self, *args, **kwargs):
         """
@@ -1619,28 +1630,46 @@ class MockedJira(object):
         """
         Mocked Jira method.
         """
-        return []
+        return [{
+            "id": 1,
+            "name": "From Fake",
+            "to": {
+                "name": "To Do"
+            },
+        }]
+    
+    def transition_issue(self, *args, **kwargs):
+        return ""
 
     def search_assignable_users_for_issues(
-        self, name, startAt=0, maxResults=20, *args, **kwargs
+        self, username=None, query=None, startAt=0, maxResults=2, *args, **kwargs
     ):
         """
         Mocked Jira method.
         Return a list :class:`JiraUser`.
         """
-        if name:
+        options = {"deployment_type": "Cloud" if self.is_jira_cloud else "Server"}
+
+        if username:
             # Mock Jira REST api bug
             return []
 
-        options = {"deployment_type": "Cloud" if self.is_jira_cloud else "Server"}
+        elif query == JIRA_USER["emailAddress"]:
+            return [User(options, None, JIRA_USER)]
 
-        # Create a list of users.
-        users = [User(options, None, JIRA_USER_2)] * maxResults + [
-            User(options, None, JIRA_USER)
-        ]
+        elif query == JIRA_USER_2["emailAddress"]:
+            return [User(options, None, JIRA_USER_2)]
+        
+        else:
+            return []
 
-        # Return the requested slice.
-        return users[startAt : startAt + maxResults]
+        # # Create a list of users.
+        # users = [User(options, None, JIRA_USER_2)] * maxResults + [
+        #     User(options, None, JIRA_USER)
+        # ]
+
+        # # Return the requested slice.
+        # return users[startAt : startAt + maxResults]
 
     def user(self, id, payload="username"):
         """

--- a/tests/python/mock_jira.py
+++ b/tests/python/mock_jira.py
@@ -1642,7 +1642,7 @@ class MockedJira(object):
         return ""
 
     def search_assignable_users_for_issues(
-        self, username=None, query=None, startAt=0, maxResults=2, *args, **kwargs
+        self, username=None, query=None, startAt=0, maxResults=20, *args, **kwargs
     ):
         """
         Mocked Jira method.
@@ -1662,14 +1662,6 @@ class MockedJira(object):
         
         else:
             return []
-
-        # # Create a list of users.
-        # users = [User(options, None, JIRA_USER_2)] * maxResults + [
-        #     User(options, None, JIRA_USER)
-        # ]
-
-        # # Return the requested slice.
-        # return users[startAt : startAt + maxResults]
 
     def user(self, id, payload="username"):
         """

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -504,15 +504,17 @@ class TestJiraSyncer(TestSyncBase):
                 },
             )
         # Test valid values in data
-        bridge.sync_in_jira(
-            "task_issue",
-            "Task",
-            2,
-            {
-                "user": {"type": "HumanUser", "id": 1},
-                "project": {"type": "Project", "id": 2},
-                "meta": SG_EVENT_META,
-            },
+        self.assertTrue(
+            bridge.sync_in_jira(
+                "task_issue",
+                "Task",
+                2,
+                {
+                    "user": {"type": "HumanUser", "id": 1},
+                    "project": {"type": "Project", "id": 2},
+                    "meta": SG_EVENT_META,
+                },
+            )
         )
 
     def test_shotgun_assignee(self, mocked_sg):

--- a/triggers/requirements.txt
+++ b/triggers/requirements.txt
@@ -10,7 +10,7 @@
 # Note: It is recommended you replace this version with the latest
 #       version release. These can be found at
 #       https://github.com/shotgunsoftware/python-api/releases
-https://github.com/shotgunsoftware/python-api/archive/v3.2.4.zip
+https://github.com/shotgunsoftware/python-api/archive/v3.3.5.zip
 
 # Allows defining env vars in a .env file that can be loaded at runtime
 python-dotenv==0.13.0


### PR DESCRIPTION
We use [createmeta](https://docs.atlassian.com/software/jira/docs/api/REST/8.18.1/#api/2/issue-getCreateIssueMeta) method to get the meta data for creating issues.

Newer versions of Jira server ≥ 9.0.0 (this excludes Jira cloud instances) deprecated this method in favor of [issuetypes](https://docs.atlassian.com/software/jira/docs/api/REST/9.8.0/#api/2/issue-getCreateIssueMetaProjectIssueTypes). This is part of the 3.5.0 version of the upstream [Jira Python client](https://github.com/pycontribs/jira) ([see implementation](https://github.com/pycontribs/jira/blob/3.5.0/jira/client.py#L1807-L1811)).

~~For this PR to take effect, we need to test the Jira Python client with version 3.5.0. 
It's possible that we need to update the dependency fork https://github.com/shotgunsoftware/jira to 3.5.0.~~

Also in this PR:

- Drops support for Python 2
- Supports Python 3.9 because of official Jira client constraints
- Adds Azure Pipelines CI
- Backwards compatible with older Jira servers.