### PR TITLE
Support add/remove watchers on cloud environments

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -73,12 +73,12 @@ LOGGING = {
     "handlers": {
         # Print out any message to stdout
         "console": {
-            "level": "INFO",
+            "level": "DEBUG",
             "class": "logging.StreamHandler",
             "formatter": "standard"
         },
         "file": {
-            "level": "INFO",
+            "level": "DEBUG",
             "class": "logging.handlers.RotatingFileHandler",
             "formatter": "standard",
             # this location should be updated to where you store logs

--- a/sg_jira/constants.py
+++ b/sg_jira/constants.py
@@ -70,7 +70,7 @@ TASK_FIELDS_MAPPING = {
     "created_by": "reporter",
     "due_date": "duedate",
     "est_in_mins": "timetracking",  # time tracking needs to be enabled in Jira.
-    "addressings_cc": None,
+    "addressings_cc": "watches",
 }
 
 # Define the mapping between Jira Issue fields and Shotgun Task fields

--- a/sg_jira/handlers/entity_issue_handler.py
+++ b/sg_jira/handlers/entity_issue_handler.py
@@ -640,7 +640,9 @@ class EntityIssueHandler(SyncHandler):
                         "Removing %s from %s watchers list."
                         % (jira_user.displayName, jira_issue)
                     )
-                    self._jira.remove_watcher(jira_issue, jira_user.user_id)
+                    # In older versions of the client (<= 3.0) we used jira_user.user_id
+                    # However, newer versions of the remove_watcher method supports name search
+                    self._jira.remove_watcher(jira_issue, jira_user.displayName)
 
         for user in added:
             if user["type"] != "HumanUser":
@@ -656,7 +658,8 @@ class EntityIssueHandler(SyncHandler):
                         "Adding %s to %s watchers list."
                         % (jira_user.displayName, jira_issue)
                     )
-                    self._jira.add_watcher(jira_issue, jira_user.user_id)
+                    # add_watcher method supports both user_id and accountId properties
+                    self._jira.add_watcher(jira_issue, jira_user.accountId)
 
     @property
     def _supported_shotgun_fields_for_jira_event(self):


### PR DESCRIPTION
Adding/removing CCs in SG (watches in Jira) had issues that are fixed in this PR.

<img width="281" alt="image" src="https://github.com/shotgunsoftware/sg-jira-bridge/assets/123113322/5fef9d6a-23a4-4d79-8bc9-3ac1441efbfe">
<img width="269" alt="image" src="https://github.com/shotgunsoftware/sg-jira-bridge/assets/123113322/b029a343-2afa-4513-9abe-03d05082f8c3">

Thanks to @loney-liu for catching and troubleshooting this.

**Also in this PR**

- Changes the default logging to DEBUG
- Changes the default constant mapping for `addressings_cc` that should have been `watches`.