### PR TITLE
Remove unexpected argument

### DIFF
--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -537,7 +537,6 @@ class JiraSession(jira.client.JIRA):
             # createmeta is not supported on Jira Server 9 and Python client 3.5.0
             create_meta_data = self.createmeta_issuetypes(
                 jira_project,
-                expand="values.fields",
             )
             if (
                 not create_meta_data["values"]


### PR DESCRIPTION
The Jira client doesn't accept this argument, see:

https://github.com/pycontribs/jira/blob/3.5.0/jira/client.py#L1732-L1735

So I'm removing it.

This affects only Jira Server.