### PR TITLE
Support createmeta_fieldtypes()

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -221,8 +221,8 @@ and define these in a ``.env`` file.
     a user password. See https://confluence.atlassian.com/x/Vo71Nw for information
     on how to generate a token.
 
-    **Jira Server** will still work with a user password and does not support
-    API tokens.
+    **Jira Server** Support API tokens. Please provide an empty string as `SGJIRA_JIRA_USER` and
+    make sure `SGJIRA_JIRA_SITE` is the REST API base URL.
 
     For more information, see: https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@
 daemonize==2.4.7; sys.platform != 'win32'
 
 # Python Jira client.
-jira==3.5.0
+jira==3.5.2
 
 # Install Shotgun API 3 from archive
-https://github.com/shotgunsoftware/python-api/archive/v3.3.5.zip
+https://github.com/shotgunsoftware/python-api/archive/v3.4.0.zip
 
 # Allows defining env vars in a .env file that can be loaded at runtime
 python-dotenv==0.13.0

--- a/sg_jira/bridge.py
+++ b/sg_jira/bridge.py
@@ -51,8 +51,7 @@ class Bridge(object):
             Jira Cloud requires the use of an API token and will not work with
             a user's password. See https://confluence.atlassian.com/x/Vo71Nw
             for information on how to generate a token.
-            Jira Server will still work with a users's password and does not
-            support API tokens.
+            Jira Server will use PAT so please provide empty string as `SGJIRA_JIRA_USER`.
 
         :param str sg_site: A ShotGrid site url.
         :param str sg_script: A ShotGrid script user name.
@@ -97,7 +96,7 @@ class Bridge(object):
         self._jira_user = jira_user
         options = (
             {"token_auth": jira_secret}
-            if jira_user == "None"
+            if not jira_user
             else {"basic_auth": (jira_user, jira_secret)}
         )
         self._jira = JiraSession(jira_site, **options)
@@ -207,7 +206,7 @@ class Bridge(object):
             raise ValueError("Missing Jira settings in %s" % full_path)
 
         missing = [
-            name for name in ["site", "user", "secret"] if not jira_settings.get(name)
+            name for name in ["site", "secret"] if not jira_settings.get(name)
         ]
         if missing:
             raise ValueError(

--- a/sg_jira/bridge.py
+++ b/sg_jira/bridge.py
@@ -96,7 +96,7 @@ class Bridge(object):
         self._jira_user = jira_user
         options = (
             {"token_auth": jira_secret}
-            if not jira_user
+            if jira_user in (None, "None", "")
             else {"basic_auth": (jira_user, jira_secret)}
         )
         self._jira = JiraSession(jira_site, **options)

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -7,6 +7,7 @@
 
 import logging
 from packaging import version
+from json.decoder import JSONDecodeError
 
 from jira import JIRAError
 import jira
@@ -46,6 +47,11 @@ class JiraSession(jira.client.JIRA):
         """
         try:
             super(JiraSession, self).__init__(jira_site, *args, **kwargs)
+        except JSONDecodeError as e:
+            logger.debug("Unable to connect to %s: %s" % (jira_site, e), exc_info=True)
+            raise RuntimeError(
+                "Unable to connect to %s. See the log for details." % jira_site
+            )
         except JIRAError as e:
             # Jira puts some huge html / javascript code in the exception
             # string so we catch it to issue a more reasonable message.

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -535,22 +535,43 @@ class JiraSession(jira.client.JIRA):
             fields_createmeta = create_meta_data["projects"][0]["issuetypes"][0]["fields"]
         else:
             # createmeta is not supported on Jira Server 9 and Python client 3.5.0
+            # Instead, we'll use the new createmeta_issuetypes and createmeta_fieldtypes methods
             create_meta_data = self.createmeta_issuetypes(
                 jira_project,
             )
+            # We asked for a single project / single issue type, so we can just pick
+            # the first entry, if it exists.
             if (
                 not create_meta_data["values"]
-                or not create_meta_data["values"][0]["fields"]
+                or not len(create_meta_data["values"]) > 0
             ):
-                logger.debug(
-                    "Create meta data for Project %s Issue type %s: %s"
+                logger.error(
+                    "Create meta data issue types for Project %s Issue type %s: %s"
                     % (jira_project, jira_issue_type.id, create_meta_data)
                 )
                 raise RuntimeError(
                     "Unable to retrieve create meta data for Project %s Issue type %s."
                     % (jira_project, jira_issue_type.id,)
                 )
-            fields_createmeta = create_meta_data["values"][0]["fields"]
+            # Get the field types because createmeta_issuetypes doesn't expand the fields
+            create_meta_data_fieldtypes = self.createmeta_fieldtypes(
+                jira_project,
+                issueTypeId=create_meta_data["values"][0]["id"],
+            )
+            if not create_meta_data_fieldtypes["values"]:
+                logger.debug(
+                    "Create meta data field types for Project %s Issue type %s: %s"
+                    % (jira_project, jira_issue_type.id, create_meta_data_fieldtypes)
+                )
+                raise RuntimeError(
+                    "Unable to retrieve create meta data for Project %s Issue type %s."
+                    % (jira_project, jira_issue_type.id,)
+                )
+            # Convert response to be backwards compatible
+            fields_createmeta = {
+                value["fieldId"]: value
+                for value in create_meta_data_fieldtypes["values"]
+            }
 
         # Make a shallow copy so we can add/delete keys
         data = dict(data)


### PR DESCRIPTION
- Bump python-api version
- Bump jira module version
- `createmeta_issuetypes` doesn't bring the field types, so this update uses `createmeta_fieldtypes` to get them.
- Support Jira PAT for Jira Server environments