### PR TITLE
SG-34502 Fix sync issues Due Date from Jira to SG

### DIFF
--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -7,7 +7,7 @@
 
 jobs:
 
-- job: Code Style Validation
+- job: flake8
   pool:
     vmImage: 'ubuntu-20.04'
 

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -7,14 +7,14 @@
 
 jobs:
 
-- job: ${{ parameters.name }}
+- job: Code Style Validation
   pool:
     vmImage: 'ubuntu-20.04'
 
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: 3.9
+      versionSpec: 3.11
       addToPath: True
       architecture: 'x64'
 

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -91,9 +91,10 @@ class JiraSession(jira.client.JIRA):
         """
         # Build a mapping from Jira field names to their id for fast lookup.
         for jira_field in self.fields():
-            field_name = jira_field["key"].lower()
-            if jira_field["name"].lower().startswith("shotgun"):
+            if self._name_is_shotgun_field(jira_field["name"]):
                 field_name = jira_field["name"].lower()
+            else:
+                field_name = jira_field["key"].lower()
             self._jira_fields_map[field_name] = jira_field["id"]
         self._jira_shotgun_type_field = self.get_jira_issue_field_id(
             JIRA_SHOTGUN_TYPE_FIELD.lower()
@@ -116,6 +117,13 @@ class JiraSession(jira.client.JIRA):
             raise RuntimeError(
                 "Missing required custom Jira field %s" % JIRA_SHOTGUN_URL_FIELD
             )
+        
+    def _name_is_shotgun_field(self, field_name):
+        return field_name.lower() in [
+            JIRA_SHOTGUN_TYPE_FIELD.lower(),
+            JIRA_SHOTGUN_ID_FIELD.lower(),
+            JIRA_SHOTGUN_URL_FIELD.lower(),
+        ]
 
     @property
     def is_jira_cloud(self):

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -91,12 +91,10 @@ class JiraSession(jira.client.JIRA):
         """
         # Build a mapping from Jira field names to their id for fast lookup.
         for jira_field in self.fields():
-            field_name = jira_field["name"].lower()
-            if field_name == "due date":
-                # "Due date" is an special case that Jira uses `duedate` in the change payload
-                field_name = "duedate"
+            field_name = jira_field["key"].lower()
+            if jira_field["name"].lower().startswith("shotgun"):
+                field_name = jira_field["name"].lower()
             self._jira_fields_map[field_name] = jira_field["id"]
-
         self._jira_shotgun_type_field = self.get_jira_issue_field_id(
             JIRA_SHOTGUN_TYPE_FIELD.lower()
         )

--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -91,7 +91,12 @@ class JiraSession(jira.client.JIRA):
         """
         # Build a mapping from Jira field names to their id for fast lookup.
         for jira_field in self.fields():
-            self._jira_fields_map[jira_field["name"].lower()] = jira_field["id"]
+            field_name = jira_field["name"].lower()
+            if field_name == "due date":
+                # "Due date" is an special case that Jira uses `duedate` in the change payload
+                field_name = "duedate"
+            self._jira_fields_map[field_name] = jira_field["id"]
+
         self._jira_shotgun_type_field = self.get_jira_issue_field_id(
             JIRA_SHOTGUN_TYPE_FIELD.lower()
         )

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1172,7 +1172,6 @@ class TestJiraSyncer(TestSyncBase):
             )["due_date"],
         )
 
-
     def test_jira_2_shotgun(self, mocked_sg):
         """
         Test syncing from Jira to ShotGrid

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -135,6 +135,24 @@ JIRA_STATUS_CHANGE_2 = {
     "fieldId": "status",
 }
 
+JIRA_DUEDATE_CHANGE = {
+    "from": "2024-03-05",
+    "to": "2024-03-30",
+    "fromString": "2024-03-05 00:00:00.0",
+    "field": "duedate",
+    "toString": "2024-03-30 00:00:00.0",
+    "fieldtype": "jira",
+    "fieldId": "duedate",
+}
+
+JIRA_DUEDATE_CHANGE_2 = {
+    "from": "2024-03-05",
+    "to": "2024-03-30",
+    "fromString": "2024-03-05 00:00:00.0",
+    "field": "duedate",
+    "toString": "2024-03-30 00:00:00.0",
+    "fieldtype": "jira",
+}
 
 JIRA_ISSUE_FIELDS = {
     "assignee": JIRA_USER,
@@ -1057,6 +1075,103 @@ class TestJiraSyncer(TestSyncBase):
         self.assertFalse(
             bridge.sync_in_shotgun("task_issue", "Issue", "FAKED-01", jira_event,)
         )
+
+    @mock.patch("shotgun_api3.lib.mockgun.Shotgun._validate_entity_data")
+    def test_jira_duedate(self, mocked_validate_fn, mocked_sg):
+        """
+        Test syncing Jira Due Date to ShotGrid
+        """
+        syncer, bridge = self._get_syncer(mocked_sg)
+        sg_entity_id = int(JIRA_EVENT["issue"]["fields"]["customfield_11501"])
+        sg_entity_type = JIRA_EVENT["issue"]["fields"]["customfield_11502"]
+
+        self.add_to_sg_mock_db(bridge.shotgun, SG_PROJECTS)
+        self.add_to_sg_mock_db(
+            bridge.shotgun,
+            {
+                "type": sg_entity_type,
+                "id": sg_entity_id,
+                "content": "%s (%d)" % (sg_entity_type, sg_entity_id),
+                "project": SG_PROJECTS[0],
+            },
+        )
+
+        # Mockgun validates all data types. In this case it checks if due_date is a date.
+        # However, we don't need it to be a Python date type since ShotGrid accepts date strings.
+        mocked_validate_fn.return_value = None
+
+        # Prepare the "server" data
+        DUE_DATE = "2024-03-05"
+        bridge.shotgun.update(sg_entity_type, sg_entity_id, {"due_date": DUE_DATE})
+        self.assertEqual(
+            DUE_DATE,
+            bridge.shotgun.find_one(
+                sg_entity_type, [["id", "is", sg_entity_id]], ["due_date"]
+            )["due_date"],
+        )
+        
+        # Prepare the JIRA payload
+        jira_event = dict(JIRA_EVENT)
+        jira_event["issue"]["fields"]["duedate"] = DUE_DATE
+        jira_event["changelog"] = {"id": "123456", "items": [JIRA_DUEDATE_CHANGE]}
+        self.assertTrue(
+            bridge.sync_in_shotgun("task_issue", "Issue", "FAKED-01", jira_event,)
+        )
+        self.assertEqual(
+            "2024-03-30",
+            bridge.shotgun.find_one(
+                sg_entity_type, [["id", "is", sg_entity_id]], ["due_date"]
+            )["due_date"],
+        )
+
+    @mock.patch("shotgun_api3.lib.mockgun.Shotgun._validate_entity_data")
+    def test_jira_duedate_without_fieldId(self, mocked_validate_fn, mocked_sg):
+        """
+        Test syncing Jira Due Date to ShotGrid
+        """
+        syncer, bridge = self._get_syncer(mocked_sg)
+        sg_entity_id = int(JIRA_EVENT["issue"]["fields"]["customfield_11501"])
+        sg_entity_type = JIRA_EVENT["issue"]["fields"]["customfield_11502"]
+
+        self.add_to_sg_mock_db(bridge.shotgun, SG_PROJECTS)
+        self.add_to_sg_mock_db(
+            bridge.shotgun,
+            {
+                "type": sg_entity_type,
+                "id": sg_entity_id,
+                "content": "%s (%d)" % (sg_entity_type, sg_entity_id),
+                "project": SG_PROJECTS[0],
+            },
+        )
+
+        # Mockgun validates all data types. In this case it checks if due_date is a date.
+        # However, we don't need it to be a Python date type since ShotGrid accepts date strings.
+        mocked_validate_fn.return_value = None
+
+        # Prepare the "server" data
+        DUE_DATE = "2024-03-05"
+        bridge.shotgun.update(sg_entity_type, sg_entity_id, {"due_date": DUE_DATE})
+        self.assertEqual(
+            DUE_DATE,
+            bridge.shotgun.find_one(
+                sg_entity_type, [["id", "is", sg_entity_id]], ["due_date"]
+            )["due_date"],
+        )
+        
+        # Prepare a JIRA payload without `fieldId` property
+        jira_event = dict(JIRA_EVENT)
+        jira_event["issue"]["fields"]["duedate"] = DUE_DATE
+        jira_event["changelog"] = {"id": "123456", "items": [JIRA_DUEDATE_CHANGE_2]}
+        self.assertTrue(
+            bridge.sync_in_shotgun("task_issue", "Issue", "FAKED-01", jira_event,)
+        )
+        self.assertEqual(
+            "2024-03-30",
+            bridge.shotgun.find_one(
+                sg_entity_type, [["id", "is", sg_entity_id]], ["due_date"]
+            )["due_date"],
+        )
+
 
     def test_jira_2_shotgun(self, mocked_sg):
         """


### PR DESCRIPTION
After some testing it seems like depending on the Jira environment, the change payload doesn't include the `fieldId` property. This field comes in the Jira Cloud environment, so this is supposed to happen only in Jira Server 8.

The bridge's internal mapping is done using the `due date` field name, but as described before, when the change payload doesn't include the `fieldId` property, the `field` property will have a value of `duedate` (without spaces).

This PR changes the use of `name` for `key` when building the internal mapping

Also, some unit tests are added.