### PR TITLE
SG-33057 update pre commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,17 +8,19 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Styles the code properly
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v5.0.0
     hooks:
     # Ensures the code's syntax is correct.
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform.
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs.
@@ -32,8 +34,7 @@ repos:
     # Removes trailing whitespaces.
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -20,8 +20,15 @@ jobs:
 
   - script: |
       pip install --upgrade pip setuptools wheel
-      pip install -r requirements.txt -r tests/requirements.txt flake8
+      pip install --upgrade -r requirements.txt -r tests/requirements.txt \
+        flake8 pre-commit
     displayName: Install dependencies
 
   - script: flake8 .
     displayName: 'Run flake8'
+
+  - bash: pre-commit autoupdate
+    displayName: Update pre-commit hook versions
+
+  - bash: pre-commit run --all
+    displayName: Validate code

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -7,7 +7,7 @@
 
 jobs:
 
-- job: flake8 & pre-commit
+- job: Code Style Validation
   pool:
     vmImage: 'ubuntu-20.04'
 
@@ -31,4 +31,4 @@ jobs:
     displayName: Update pre-commit hook versions
 
   - bash: pre-commit run --all
-    displayName: Validate code
+    displayName: Validate code with pre-commit

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -7,7 +7,7 @@
 
 jobs:
 
-- job: flake8
+- job: flake8 & pre-commit
   pool:
     vmImage: 'ubuntu-20.04'
 

--- a/azure-pipelines/flake8.yml
+++ b/azure-pipelines/flake8.yml
@@ -7,7 +7,8 @@
 
 jobs:
 
-- job: Code Style Validation
+- job: code_style_validation
+  displayName: Code Style Validation
   pool:
     vmImage: 'ubuntu-20.04'
 


### PR DESCRIPTION
- Add pre-commit call in CI (Azure)
- Cleanup and update `.pre-commit-config.yaml` file
  - Update pre-commit-hooks to version `v5.0.0`
  - Update black hook to version `25.1.0`
  - Update black hook URL
  - Use global `default_language_version` instead of individuals `language_version`


Related to shotgunsoftware/tk-ci-tools#58