### PR TITLE
[SG-38736] Properly encode server response

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -232,7 +232,9 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             self.post_response(
                 200,
                 six.ensure_binary("The server is alive"),
-                six.ensure_binary(HMTL_TEMPLATE % ("The server is alive", "The server is alive", "")),
+                six.ensure_binary(
+                    HMTL_TEMPLATE % ("The server is alive", "The server is alive", "")
+                ),
             )
             return
 

--- a/webapp.py
+++ b/webapp.py
@@ -231,8 +231,8 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         if not path_parts:
             self.post_response(
                 200,
-                "The server is alive",
-                HMTL_TEMPLATE % ("The server is alive", "The server is alive", ""),
+                six.ensure_binary("The server is alive"),
+                six.ensure_binary(HMTL_TEMPLATE % ("The server is alive", "The server is alive", "")),
             )
             return
 


### PR DESCRIPTION
When the server returns a response, make sure to correctly encapsulate it