### PR TITLE
SG-42067 - Add JIRABRIDGE User-Agent

### DIFF
--- a/sg_jira/shotgun_session.py
+++ b/sg_jira/shotgun_session.py
@@ -56,6 +56,9 @@ class ShotgunSession(object):
 
         self._shotgun = shotgun_api3.Shotgun(base_url, script_name, *args, **kwargs)
 
+        # Add custom User-Agent identifier
+        self._shotgun.add_user_agent("JIRABRIDGE")
+
         self._shotgun_entity_types = []  # will be used to store FPT entities list
         self._shotgun_schemas = {}  # will be used to store FPT fields by entity type
 

--- a/tests/test_shotgun_session.py
+++ b/tests/test_shotgun_session.py
@@ -13,6 +13,7 @@ from shotgun_api3.lib import mockgun
 from test_base import TestBase
 
 import sg_jira
+from sg_jira.shotgun_session import ShotgunSession
 
 
 # Mock Flow Production Tracking with mockgun, this works only if the code uses shotgun_api3.Shotgun
@@ -130,3 +131,15 @@ class TestShotgunSession(TestBase):
         )
 
         self.assertEqual(consolidated_timelog, None)
+
+    def test_user_agent_is_set(self, mocked_sg):
+        """Test that JIRABRIDGE User-Agent identifier is added"""
+
+        mock_sg_instance = mock.Mock()
+        mocked_sg.return_value = mock_sg_instance
+
+        ShotgunSession("https://test.shotgunstudio.com", "test_script", "test_key")
+
+        mock_sg_instance.add_user_agent.assert_called_once()
+        user_agent_arg = mock_sg_instance.add_user_agent.call_args[0][0]
+        self.assertIn("JIRABRIDGE", user_agent_arg.upper())

--- a/tests/test_update_shotgun_users.py
+++ b/tests/test_update_shotgun_users.py
@@ -6,13 +6,14 @@
 # this software in either electronic or hard copy form.
 #
 import os
+from unittest import mock
 
 from mock_jira import JIRA_PROJECT, JIRA_USER, JIRA_USER_2
 from shotgun_api3.lib import mockgun
 from test_base import TestBase
 
 from sg_jira.jira_session import JiraSession
-from update_shotgun_users import sync_jira_users_into_shotgun
+from update_shotgun_users import main, sync_jira_users_into_shotgun
 
 
 class TestUpdateShotgunUsers(TestBase):
@@ -106,6 +107,28 @@ class TestUpdateShotgunUsers(TestBase):
         )
         sync_jira_users_into_shotgun(self._shotgun, self._jira, "UTest")
         self._assert_sg_users_account_ids(None, JIRA_USER, JIRA_USER_2, None)
+
+    @mock.patch("update_shotgun_users.sync_jira_users_into_shotgun")
+    @mock.patch("update_shotgun_users.JiraSession")
+    @mock.patch("update_shotgun_users.Shotgun")
+    @mock.patch("update_shotgun_users._get_settings")
+    def test_user_agent_is_set(self, mock_settings, mock_shotgun, mock_jira, mock_sync):
+        """Test that JIRABRIDGE User-Agent identifier is added to the Shotgun connection."""
+        mock_settings.return_value = (
+            None,
+            {"site": "https://test.shotgunstudio.com", "script_name": "test", "script_key": "key"},
+            {"site": "https://test.atlassian.net", "user": "user", "secret": "secret"},
+            None,
+        )
+        mock_sg_instance = mock.Mock()
+        mock_shotgun.return_value = mock_sg_instance
+        mock_jira_instance = mock.Mock()
+        mock_jira_instance.is_jira_cloud = True
+        mock_jira.return_value = mock_jira_instance
+
+        main()
+
+        mock_sg_instance.add_user_agent.assert_called_once_with("JIRABRIDGE")
 
     def _assert_sg_users_account_ids(self, *jira_users):
         """

--- a/tests/test_update_shotgun_users.py
+++ b/tests/test_update_shotgun_users.py
@@ -116,7 +116,11 @@ class TestUpdateShotgunUsers(TestBase):
         """Test that JIRABRIDGE User-Agent identifier is added to the Shotgun connection."""
         mock_settings.return_value = (
             None,
-            {"site": "https://test.shotgunstudio.com", "script_name": "test", "script_key": "key"},
+            {
+                "site": "https://test.shotgunstudio.com",
+                "script_name": "test",
+                "script_key": "key",
+            },
             {"site": "https://test.atlassian.net", "user": "user", "secret": "secret"},
             None,
         )

--- a/update_shotgun_users.py
+++ b/update_shotgun_users.py
@@ -147,6 +147,7 @@ def main():
         script_name=shotgun_settings["script_name"],
         api_key=shotgun_settings["script_key"],
     )
+    sg.add_user_agent("JIRABRIDGE")
 
     sync_jira_users_into_shotgun(sg, jira, project)
 


### PR DESCRIPTION
## Summary
Adds a custom User-Agent identifier to Shotgun API requests.

## Changes
  - Modified `sg_jira/shotgun_session.py` to append "JIRABRIDGE" to the User-Agent
  - Added unit test to verify User-Agent is set correctly

## Result
```
shotgun-json (3.6.2); Python 3.9 (Mac); ssl LibreSSL 2.8.3 (validate); JIRABRIDGE 
```