### PR TITLE
SG-41625: Fix ticket creation with latest JIRA lib

### DIFF
--- a/sg_jira/jira_session.py
+++ b/sg_jira/jira_session.py
@@ -344,7 +344,7 @@ class JiraSession(jira.client.JIRA):
         # Direct user search with their email
         logger.debug("Looking up %s in assignable users" % user_email)
         search_params = dict(
-            project=jira_project,
+            project=jira_project.key,
             issueKey=jira_issue.key if jira_issue else None,
             maxResults=JIRA_RESULT_PAGING,
         )


### PR DESCRIPTION
Here is the error that I had when creating a new task:
```
2026-03-25 12:51:53,912 ERROR [bridge] Object of type Project is not JSON serializable
Traceback (most recent call last):
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/sg_jira/bridge.py", line 362, in sync_in_jira
    synced = handler.process_shotgun_event(entity_type, entity_id, event)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/sg_jira/handlers/task_issue_handler.py", line 207, in process_shotgun_event
    jira_issue = self._create_jira_issue_for_entity(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/sg_jira/handlers/entity_issue_handler.py", line 195, in _create_jira_issue_for_entity
    jira_user = self.get_jira_user(user["email"], jira_project)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/sg_jira/handlers/sync_handler.py", line 132, in get_jira_user
    jira_user = self._jira.find_jira_user(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/sg_jira/jira_session.py", line 357, in find_jira_user
    jira_users = search_method(**search_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/venv3_11/lib/python3.11/site-packages/jira/client.py", line 3784, in search_assignable_users_for_issues
    return self._fetch_pages(
           ^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/venv3_11/lib/python3.11/site-packages/jira/client.py", line 808, in _fetch_pages
    page_params = json_params()
                  ^^^^^^^^^^^^^
  File "/Users/sauved/travail/tests/jira-bridge/sg-jira-bridge/venv3_11/lib/python3.11/site-packages/jira/client.py", line 806, in json_params
    return json.loads(json.dumps(params.copy())) if params else {}
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/.asdf/installs/python/3.11.13/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/.asdf/installs/python/3.11.13/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sauved/.asdf/installs/python/3.11.13/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/Users/sauved/.asdf/installs/python/3.11.13/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Project is not JSON serializable
```